### PR TITLE
Responsividade em chrome ajustada

### DIFF
--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -71,3 +71,8 @@
   }
 
 }
+@media screen and (max-width: 600px){
+  .footer-body .dark-logo-container img {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Foi identificado que a logo do footer estava fixa em 400px, foi inserido um media query  para tela com menos de 600px, onde o footer ocupa 100% de largura de proporção.